### PR TITLE
fix build exception due to invalid contents of designer.

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -116,7 +116,6 @@
             this.cbl_names.Size = new System.Drawing.Size(288, 52);
             this.cbl_names.TabIndex = 4;
             this.cbl_names.ThreeDCheckBoxes = true;
-            this.cbl_names.SelectedIndexChanged += new System.EventHandler(this.checkedListBox1_SelectedIndexChanged);
             // 
             // notifyIcon1
             // 


### PR DESCRIPTION
I suspect this line got in the designer by mistake some how, as it completely blocks the form from regenerating. Probably something was edited, saved, and the designer file wasn't saved or got reset by accident or something. This breaks builds as of the "adding hscroll support" commit. 
